### PR TITLE
Fix collect logs task

### DIFF
--- a/migration/infrared/tripleo-ovn-migration/main.yml
+++ b/migration/infrared/tripleo-ovn-migration/main.yml
@@ -190,7 +190,8 @@
                   echo "exit" > {{ ovn_migration_working_dir}}/_pinger_cmd.txt
         always:
             - name: Fetch ovn_migration log directory
-              fetch:
+              synchronize:
                   src: "{{ ovn_migration_working_dir }}"
                   dest: "{{ inventory_dir }}/ovn_migration/"
+                  mode: pull
               when: install is defined


### PR DESCRIPTION
This patch replaces the 'fetch' module which is not intended
for copying dirs by 'synchronize'.

NOTE: The use of this module requires rsync to be present on
local and remote servers but it's used already in infrared
so it's safe to assume that it exists.
Signed-off-by: Daniel Alvarez <dalvarez@redhat.com>